### PR TITLE
Delay file opening until first write

### DIFF
--- a/io/filewriter.go
+++ b/io/filewriter.go
@@ -1,0 +1,35 @@
+package io
+
+import (
+	"io"
+	"os"
+
+	"github.com/go-kivik/couchdb/chttp"
+	"github.com/go-kivik/kouch/internal/errors"
+)
+
+type delayedOpenWriter struct {
+	filename string
+	clobber  bool
+	w        io.Writer
+}
+
+var _ io.Writer = &delayedOpenWriter{}
+
+func (w *delayedOpenWriter) Write(p []byte) (int, error) {
+	if w.w == nil {
+		var err error
+		w.w, err = w.open()
+		if err != nil {
+			return 0, &errors.ExitError{Err: err, ExitCode: chttp.ExitWriteError}
+		}
+	}
+	return w.w.Write(p)
+}
+
+func (w *delayedOpenWriter) open() (io.Writer, error) {
+	if w.clobber {
+		return os.Create(w.filename)
+	}
+	return os.OpenFile(w.filename, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0755)
+}

--- a/io/io.go
+++ b/io/io.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/go-kivik/couchdb/chttp"
 	"github.com/go-kivik/kouch/internal/errors"
 	"github.com/spf13/cobra"
 )
@@ -74,18 +73,10 @@ func SelectOutput(cmd *cobra.Command) (io.Writer, error) {
 		return nil, err
 	}
 
-	f, err := openFile(output, clobber)
-	if err != nil {
-		return nil, &errors.ExitError{Err: err, ExitCode: chttp.ExitWriteError}
-	}
-	return f, nil
-}
-
-func openFile(filename string, clobber bool) (io.Writer, error) {
-	if clobber {
-		return os.Create(filename)
-	}
-	return os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0755)
+	return &delayedOpenWriter{
+		filename: output,
+		clobber:  clobber,
+	}, nil
 }
 
 // SelectOutputProcessor selects and configures the desired output processor


### PR DESCRIPTION
This will prevent creating/clobbering files when a network request fails,
for example.